### PR TITLE
Update to Factorio 2.1 (drops 2.0 support)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.6.0
+Date: 2026-06-26
+  Changes:
+    - Marked compatible with Factorio 2.1. The 2.0 code loads and runs unchanged on 2.1; no code changes were required.
+---------------------------------------------------------------------------------------------------
 Version: 1.5.4
 Date: 2026-06-08
   Fixes:

--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
   "name": "AbandonedRuins_updated_fork",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "title": "Abandoned Ruins - Updated",
   "author": "roland77, Keysivi, Gangsir, Bilka",
   "homepage": "https://github.com/Quix0r/AbandonedRuins",
-  "factorio_version": "2.0",
+  "factorio_version": "2.1",
   "description": "This mod doesn't do anything by itself. You need to install ruin-set mods or no ruin will be spawned.\n\nThis mod is based on 1.1.6 (abondoned mod?) and @Keysivi's changes to move out base ruins to an external mod and contains many fixes for Factorio 2.0. Abandoned Ruins - Updated adds randomly spawns ruins in the world. These ruins are destroyed fragments of bases, forts, small oases, and more.\n\nExplore them for loot, adventure, or entertainment, but beware, some still have running defenses from the last player that landed on the planet, with more successful colonies having better defenses.",
   "dependencies":
   [


### PR DESCRIPTION
Marks the mod compatible with Factorio 2.1.

Change is `info.json` only: `factorio_version` → 2.1, version → 1.6.0.

This isn't a blind version flip — I grepped the Lua for everything removed or renamed in 2.1 (LuaEntity `active`/`minable` writes, `fluidbox`, `neighbours`, `pipette_entity`, `defines.inventory.*` crafter renames, recipe `category`→`categories`, …) and the mod uses none of it, so the 2.0 code runs unchanged.

Verified on Factorio 2.1.8 with Space Age: settings/data/control stages load cleanly (`--dump-data` + map `--create`), and the release build was playtested in-game — ruins spawn with loot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
