### PR TITLE
Add missing locale for the "expensive sanity checks" setting

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -9,6 +9,7 @@ ruins-large-ruin-chance=Chance for a large ruin per chunk
 ruins-medium-ruin-chance=Chance for a medium ruin per chunk
 ruins-small-ruin-chance=Chance for a small ruin per chunk
 ruins-enable-spawn-ruins-all-planets=Enable spawning ruins on all planets?
+ruins-expensive-sanity-checks=Enable expensive sanity checks
 current-ruin-set=Ruin set
 
 [mod-setting-description]
@@ -22,6 +23,7 @@ ruins-large-ruin-chance=Chance to spawn a large ruin in a generated chunk, 0-1 f
 ruins-medium-ruin-chance=Chance to spawn a medium ruin in a generated chunk, 0-1 float value, eg 0.1 is 10% chance.
 ruins-small-ruin-chance=Chance to spawn a small ruin in a generated chunk, 0-1 float value, eg 0.1 is 10% chance.
 ruins-enable-spawn-ruins-all-planets=This setting affects the game only once in advance. After saving the game, it won't affect anymore (per save-game). If enabled, ruins will be spawned on any planet according to the mod-settings, if disabled ruins will only spawn on Nauvis and default planets of the Space Age mod.
+ruins-expensive-sanity-checks=Runs additional validation while spawning ruins to catch invalid ruin sets, planets and surfaces. Recommended for smaller or heavily modded games; disable only if you need the extra performance. Always active while the debug log is enabled.
 current-ruin-set=Which collection of ruins is used. Mods can add their own ruin sets.
 
 [string-mod-setting]


### PR DESCRIPTION
Adds the missing English locale for the `ruins-expensive-sanity-checks` startup setting.

It's defined in `settings.lua` and used by the spawning/queue/ruin-set sanity checks, but had no `[mod-setting-name]`/`[mod-setting-description]` entry, so the in-game mod settings showed:

> Unknown key: "mod-setting-name.ruins-expensive-sanity-checks"

English is the fallback locale, so this fixes the label for all languages. Pre-existing — affects the current 2.0 releases too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
