### PR TITLE
Fix typos in the spawn-tick-seconds setting description

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -18,7 +18,7 @@ ruins-enable-debug-log=Enables __many__ of debug messages. Please enable them wh
 ruins-enable-debug-utils==Enables __a lot__ debug messages for the library "utilities". This is extremely been used, please keep this generally disabled.
 ruins-enable-debug-on-tick=Enables __extremly many__ debug messages for the event `on_tick`. This is extremely been used, please keep this generally disabled.
 ruins-min-distance-from-spawn=Minimum distance in tiles from spawn (also known as "tile zero").
-ruins-spawn-tick-seconds=Seconds between zwo attempts to spawn ruins in newly generated map tile. To small values can impact performance, to high values delay spawning.
+ruins-spawn-tick-seconds=Seconds between two attempts to spawn ruins in a newly generated map tile. Too small values can impact performance, too high values delay spawning.
 ruins-large-ruin-chance=Chance to spawn a large ruin in a generated chunk, 0-1 float value, eg 0.1 is 10% chance.
 ruins-medium-ruin-chance=Chance to spawn a medium ruin in a generated chunk, 0-1 float value, eg 0.1 is 10% chance.
 ruins-small-ruin-chance=Chance to spawn a small ruin in a generated chunk, 0-1 float value, eg 0.1 is 10% chance.


### PR DESCRIPTION
Fixes typos in the `ruins-spawn-tick-seconds` setting description:

- `zwo` → `two`
- `To small` → `Too small`
- `to high` → `too high`
- adds a missing article ("a newly generated map tile")

Pre-existing — affects the current 2.0 releases too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
