### PR TITLE
Credit @tobiaspal instead of @pault-pg in the changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,14 +2,14 @@
 Version: 1.6.0
 Date: 2026-06-27
   Experimental:
-    - changed version of supported Factorio version to `2.1` as suggested by @pault-pg@github.com
+    - changed version of supported Factorio version to `2.1` as suggested by @tobiaspal
 ---------------------------------------------------------------------------------------------------
 Version: 1.5.5
 Date: 2026-06-26
   Changes:
-   - @pault-pg has added missing language string for "expensive sanity checks" setting (thank you!),
+   - @tobiaspal has added missing language string for "expensive sanity checks" setting (thank you!),
      PR #7
-   - some tpzos fixed, thanks to @pault-pg, PR #8
+   - some tpzos fixed, thanks to @tobiaspal, PR #8
    - bumped version for `base` mod to 2.0.77
 ---------------------------------------------------------------------------------------------------
 Version: 1.5.4


### PR DESCRIPTION
The changelog credits these to `@pault-pg`, but that's my work account — my personal GitHub (the one that opened the PRs) is `@tobiaspal`. Could you switch the credit?

This fixes the lines on `experimental-2.1`. The PR #7 / #8 credit lines are also on `master`; I left those for you to apply per your `master` ↔ `experimental-2.1` flow — happy to send a `master` PR too if that's simpler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
