### PR TITLE
Fix Debug/Test World spawning and weighted ruin sets

### DIFF
--- a/lua/spawning.lua
+++ b/lua/spawning.lua
@@ -437,7 +437,7 @@ spawning.spawn_ruin = function(ruin, half_size, center, surface)
   end
 
   if debug_log then log(string.format("[spawn_ruin]: surface.name='%s',DEBUG_SURFACE_NAME='%s'", surface.name, constants.DEBUG_SURFACE_NAME)) end
-  if surface.name ~= constants.DEBUG_SURFACE_NAME and clear_area(half_size, center, surface) then
+  if surface.name == constants.DEBUG_SURFACE_NAME or clear_area(half_size, center, surface) then
     local variables = {}
 
     if debug_log then log(string.format("[spawn_ruin]: ruin.variables[]='%s'", type(ruin.variables))) end

--- a/scenarios/debug/control.lua
+++ b/scenarios/debug/control.lua
@@ -61,11 +61,37 @@ script.on_event(defines.events.on_player_created, function(event)
     return
   end
 
+  local ruin_sizes = remote.call("AbandonedRuins", "get_ruin_sizes")
+  local display_ruin_set = {}
   local total_ruins_amount = 0
-  for _, size in pairs(remote.call("AbandonedRuins", "get_ruin_sizes")) do
-    log(string.format("[on_player_created]: size='%s'", size))
-    total_ruins_amount = total_ruins_amount + #ruin_set[size]
+
+  -- The runtime ruin set may contain repeated references used as selection weights.
+  -- The debug world should display each actual ruin definition once.
+  for _, size in pairs(ruin_sizes) do
+    local source_ruins = ruin_set[size] or {}
+    local unique_ruins = {}
+    local seen = {}
+
+    for _, ruin in pairs(source_ruins) do
+      if not seen[ruin] then
+        seen[ruin] = true
+        unique_ruins[#unique_ruins + 1] = ruin
+      end
+    end
+
+    display_ruin_set[size] = unique_ruins
+    total_ruins_amount = total_ruins_amount + #unique_ruins
+    log(string.format(
+      "[on_player_created]: size='%s',weighted=%d,unique=%d",
+      size, #source_ruins, #unique_ruins
+    ))
   end
+
+  if total_ruins_amount == 0 then
+    utils.output_message("Abandoned Ruins: Current ruin-set is empty! Will not create debug world.")
+    return
+  end
+
   local chunk_radius = math.ceil(math.sqrt(total_ruins_amount) / 2)
 
   log(string.format("[on_player_created]: total_ruins_amount=%d,chunk_radius=%.2f", total_ruins_amount, chunk_radius))
@@ -94,7 +120,8 @@ script.on_event(defines.events.on_player_created, function(event)
   local x = -chunk_radius
   local y = -chunk_radius
 
-  for size, ruins in pairs(ruin_set) do
+  for _, size in pairs(ruin_sizes) do
+    local ruins = display_ruin_set[size] or {}
     log(string.format("[on_player_created]: size='%s',ruins()=%d", size, #ruins))
     local half_size = spawning.ruin_half_sizes[size]
 


### PR DESCRIPTION
This fixes two remaining issues in the included Debug/Test World.

1. Debug-surface spawning

In 1.5.6, the new debug-surface condition skips clear_area(), but also
skips the entire ruin-spawn block:

    if surface.name ~= constants.DEBUG_SURFACE_NAME
        and clear_area(...) then

Changing it to:

    if surface.name == constants.DEBUG_SURFACE_NAME
        or clear_area(...) then

keeps clear_area() disabled on the debug surface while still allowing
spawn_ruin() to continue.

2. Weighted ruin sets in the Debug/Test World

Weighted ruin registrations intentionally contain the same ruin table
multiple times to influence normal spawn probability.

The Debug/Test World should display each actual ruin definition once,
not every weighted selection slot.

The debug scenario now de-duplicates identical ruin table references
for display only.

Normal ruin spawning and weighting are unchanged.

Tested successfully with Factorio 2.0.77 and a large K2/SE mod stack and [Abandoned Ruins - Combined](https://mods.factorio.com/mod/AbandonedRuins-Combined).
The Debug/Test World loads correctly and displays the registered ruins.

Greetings MoSII2710 aka Flagran 